### PR TITLE
ヘッダーを修正（ログイン画面&ユーザー登録画面）

### DIFF
--- a/app/views/layouts/_devise-header.html.haml
+++ b/app/views/layouts/_devise-header.html.haml
@@ -1,0 +1,5 @@
+.Header
+  .Header__name.mini-name
+    てんさくん
+  .Header__right
+    = link_to "トップページ", root_path, method: :get, class: "Header__right--index"

--- a/app/views/students/registrations/new.html.haml
+++ b/app/views/students/registrations/new.html.haml
@@ -1,4 +1,4 @@
-= render partial: "layouts/mini-header"
+= render partial: "layouts/devise-header"
 .regist-form
   %h2.Regist-title 生徒登録
   = form_for(resource, as: resource_name, class: "Regist", url: registration_path(resource_name)) do |f|

--- a/app/views/students/sessions/new.html.haml
+++ b/app/views/students/sessions/new.html.haml
@@ -1,4 +1,4 @@
-= render partial: "layouts/mini-header"
+= render partial: "layouts/devise-header"
 .session-form
   %h2.Session-title 生徒ログイン
   = form_for(resource, as: resource_name, class: "Session", url: session_path(resource_name)) do |f|

--- a/app/views/teachers/registrations/new.html.haml
+++ b/app/views/teachers/registrations/new.html.haml
@@ -1,4 +1,4 @@
-= render partial: "layouts/mini-header"
+= render partial: "layouts/devise-header"
 .regist-form
   %h2.Regist-title 講師登録
   = form_for(resource, as: resource_name, class: "Regist", url: registration_path(resource_name)) do |f|

--- a/app/views/teachers/sessions/new.html.haml
+++ b/app/views/teachers/sessions/new.html.haml
@@ -1,4 +1,4 @@
-= render partial: "layouts/mini-header"
+= render partial: "layouts/devise-header"
 .session-form
   %h2.Session-title 講師ログイン
   = form_for(resource, as: resource_name, class: "Session", url: session_path(resource_name)) do |f|


### PR DESCRIPTION
# What
ログイン画面とユーザー登録画面のヘッダーを修正。
具体的にはトップページへのリンクを追加した。

# Why
ログイン画面とユーザー登録画面でトップページに戻る方法がなかったから。